### PR TITLE
Fix `t.rb` working in sub-directories of the git repo

### DIFF
--- a/libexec/t.rb
+++ b/libexec/t.rb
@@ -243,8 +243,8 @@ module TdotRB
 
   module GitChangedFiles
     def self.cmd(config, test_paths)
-      [ "git diff --no-ext-diff --name-only #{config.changed_ref}", # changed files
-        "git ls-files --others --exclude-standard"                  # added files
+      [ "git diff --no-ext-diff --relative --name-only #{config.changed_ref}", # changed files
+        "git ls-files --others --exclude-standard"                             # added files
       ].map{ |c| "#{c} -- #{test_paths.join(" ")}" }.join(" && ")
     end
 


### PR DESCRIPTION
This fixes `t.rb` working in sub-directories of the git repo by
adding the `--relative` flag to the `git diff` command. For
example, if you have the following folder structure:

    gitrepo
     - .git
     - subdirectory
        - .t.yml
        - tests

and you are in the `subdirectory` folder, if you ran `t -c` to
detect changes in your `tests` folder, it previously wouldn't see
any. This is because the `git diff` command returned results like
`gitrepo/subdirectory/tests/something` and then the test running
logic wouldn't think it's a valid file for it to run. The
`--relative` option makes it return `subdirectory/tests/something`
which works as expected with the rest of the test running logic.
